### PR TITLE
redNAND tweaks + 8gb dumping support

### DIFF
--- a/source/dump.c
+++ b/source/dump.c
@@ -860,7 +860,7 @@ int _dump_restore_mlc(u32 base)
     // Check to see if the first block matches, if so, ask the user if they want to continue.
     if(memcmp(sdcard_buf, mlc_buf, SDMMC_DEFAULT_BLOCKLEN * SDHC_BLOCK_COUNT_MAX) == 0) {
         printf("MLC: First blocks match, continue restoring?\n");
-        if(console_abort_confirmation_power_no_eject_yes()) return;
+        if(console_abort_confirmation_power_no_eject_yes()) return -1;
         printf("MLC: Continuing restore...\n");
     } else {
         printf("MLC: First blocks do not match!\n");

--- a/source/dump.c
+++ b/source/dump.c
@@ -1278,6 +1278,12 @@ int _dump_partition_rednand(void)
     const u32 data_sectors = 0x100000 / SDMMC_DEFAULT_BLOCKLEN;
 
     u32 end = (u32)sdcard_get_sectors() & 0xFFFF0000;
+    u32 rednand_size = slc_sectors * 2 + mlc_sectors + data_sectors;
+    if (rednand_size > end) {
+        printf("SD card is too small! Have 0x%08lX (0x%08lX) sectors, need at least 0x%08lX.\n", (u32)sdcard_get_sectors(), end, rednand_size);
+        return -2;
+    }
+
     u32 slccmpt_base = end - slc_sectors;
     u32 slc_base = slccmpt_base - slc_sectors;
     u32 mlc_base = slc_base - mlc_sectors;
@@ -1300,7 +1306,7 @@ int _dump_partition_rednand(void)
     fres = f_mkfs("sdmc:", 0, 0, fat_base, fat_base + fat_sectors);
     if(fres != FR_OK) {
         printf("Failed to format card (%d)!\n", fres);
-        return -2;
+        return -3;
     }
 
     printf("Updating MBR...\n");
@@ -1308,7 +1314,7 @@ int _dump_partition_rednand(void)
     res = sdcard_read(0, 1, mbr);
     if(res) {
         printf("Failed to read MBR (%d)!\n", res);
-        return -3;
+        return -4;
     }
 
     memset(part2, 0x00, 0x10);
@@ -1329,7 +1335,7 @@ int _dump_partition_rednand(void)
     res = sdcard_write(0, 1, mbr);
     if(res) {
         printf("Failed to write MBR (%d)!\n", res);
-        return -4;
+        return -5;
     }
 
     // Mandatory backup


### PR DESCRIPTION
Adds an error when attempting to format redNAND on a card that's too small, and changes the hardcoded 32GB sector counts to use a helper function.

There are unused sectors at the end of the eMMC - I took the value of `e90000` from my 8GB Samsung console, but there are known to be Toshiba 8GB consoles too:
![image](https://github.com/shinyquagsire23/minute_minute/assets/8533313/2f632903-7185-4023-9648-c9f2d704e138)

I have no idea what the physical size of these chips are, if they're bigger than Samsungs then this code will need to be updated.

With that said I was able to dump successfully onto a 32GB card, and while stroopwafel doesn't support 8gb redNAND yet the dump did pass a visual inspection in a hex editor. Restoring is untested.