### PR TITLE
Make fw_fastboot.img compatible with linux-wiiu

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -156,7 +156,7 @@ static bool load_fw_from_sd_fat(void){
         }
         res = f_read(&f, (void*)ALL_PURPOSE_TMP_BUF, 0x800000, &read);
         f_close(&f);
-        if (res != FR_OK) {
+        if (res != FR_OK || read < 327680) {
             return false;
         }
 


### PR DESCRIPTION
Check size of fw.img on sdcard and refuse to load it if it is smaller than 320KiB, during fastboot. Typically a fw.img of petitboot is about 256KiB, making it compatible with linux-wiiu.

Not tested but should work...

Related: isfshax/isfshax#11